### PR TITLE
Fix PDF viewer and language toggle

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -18,19 +18,23 @@
      * Language Toggle Functionality
      */
     function initLanguageToggle() {
-        const languageButtons = $('.language-toggle button');
-        
+        const languageButtons = $('.language-toggle .lang-btn');
+
         languageButtons.on('click', function() {
             const selectedLang = $(this).data('lang');
-            const currentLang = $('body').hasClass('rtl') ? 'ar' : 'en';
-            
+
+            if (!selectedLang) {
+                return;
+            }
+
+            const currentLang = ($('html').attr('dir') === 'rtl' || $('body').hasClass('rtl')) ? 'ar' : 'en';
+
             if (selectedLang !== currentLang) {
                 switchLanguage(selectedLang);
-                
-                // Update active button
-                languageButtons.removeClass('active');
-                $(this).addClass('active');
             }
+
+            languageButtons.removeClass('active');
+            $(this).addClass('active');
         });
     }
     
@@ -39,20 +43,24 @@
      */
     function switchLanguage(lang) {
         if (lang === 'ar') {
-            $('body').removeClass('ltr').addClass('rtl');
+            $('body').removeClass('ltr').addClass('rtl').attr('dir', 'rtl');
             $('html').attr('lang', 'ar').attr('dir', 'rtl');
         } else {
-            $('body').removeClass('rtl').addClass('ltr');
+            $('body').removeClass('rtl').addClass('ltr').attr('dir', 'ltr');
             $('html').attr('lang', 'en').attr('dir', 'ltr');
         }
-        
+
         // Toggle content visibility based on language
         $('.lang-ar').toggle(lang === 'ar');
         $('.lang-en').toggle(lang === 'en');
-        
+
         // Save language preference
-        localStorage.setItem('arabBoard2025Lang', lang);
-        
+        try {
+            localStorage.setItem('arabBoard2025Lang', lang);
+        } catch (error) {
+            console.warn('Unable to persist language preference:', error);
+        }
+
         // Update text content dynamically
         updateTextContent(lang);
     }
@@ -290,13 +298,20 @@
      * Load saved language preference
      */
     function loadLanguagePreference() {
-        const savedLang = localStorage.getItem('arabBoard2025Lang');
-        
-        if (savedLang) {
-            $(`.language-toggle button[data-lang="${savedLang}"]`).click();
+        let savedLang = null;
+
+        try {
+            savedLang = localStorage.getItem('arabBoard2025Lang');
+        } catch (error) {
+            console.warn('Unable to read stored language preference:', error);
+        }
+
+        if (savedLang === 'ar' || savedLang === 'en') {
+            $(`.language-toggle .lang-btn[data-lang="${savedLang}"]`).trigger('click');
         } else {
             // Default to Arabic if no preference is saved
-            $('.language-toggle button[data-lang="ar"]').addClass('active');
+            switchLanguage('ar');
+            $('.language-toggle .lang-btn[data-lang="ar"]').addClass('active');
         }
     }
     

--- a/functions.php
+++ b/functions.php
@@ -114,6 +114,33 @@ function arab_board_2025_scripts() {
 }
 add_action('wp_enqueue_scripts', 'arab_board_2025_scripts');
 
+/**
+ * Build a proxied viewer URL for PDF files so they can be displayed safely in iframes.
+ *
+ * @param string $pdf_url Original PDF URL.
+ * @param string $day     Identifier for the day/section using the PDF.
+ *
+ * @return string Proxied viewer URL or the original URL if encoding fails.
+ */
+function arab_board_2025_get_protected_pdf_url($pdf_url, $day = '') {
+    if (empty($pdf_url)) {
+        return '';
+    }
+
+    $data = array(
+        'url' => esc_url_raw($pdf_url),
+        'day' => sanitize_key($day),
+    );
+
+    $encoded = base64_encode(wp_json_encode($data));
+
+    if (empty($encoded)) {
+        return esc_url_raw($pdf_url);
+    }
+
+    return trailingslashit(get_template_directory_uri()) . 'pdf-proxy.php?file=' . rawurlencode($encoded);
+}
+
 // Add admin styles and scripts
 function arab_board_2025_admin_scripts() {
     wp_enqueue_media();


### PR DESCRIPTION
## Summary
- route schedule PDFs through the bundled proxy viewer and improve iframe fallback messaging
- align language toggle buttons with data attributes and persistence so Arabic/English switching works reliably
- add a helper for generating protected PDF URLs and harden the shared language toggle script

## Testing
- php -l front-page.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_b_68da6cd595488330875418f85b2b05d7